### PR TITLE
Fix python3 support

### DIFF
--- a/gpp-decrypt.py
+++ b/gpp-decrypt.py
@@ -25,7 +25,7 @@ def decrypt(cpass):
     decoded = base64.b64decode(epass)
     key = b'\x4e\x99\x06\xe8\xfc\xb6\x6c\xc9\xfa\xf4\x93\x10\x62\x0f\xfe\xe8' \
           b'\xf4\x96\xe8\x06\xcc\x05\x79\x90\x20\x9b\x09\xa4\x33\xb6\x6c\x1b'
-    iv = '\x00' * 16
+    iv = b'\x00' * 16
     aes = AES.new(key, AES.MODE_CBC, iv)
     return aes.decrypt(decoded).decode(encoding='ascii').strip()
 


### PR DESCRIPTION
In Python3 you must append a `b` before a string to make it a bytearray